### PR TITLE
Update Off-boarding Procedures

### DIFF
--- a/meta/resources/offboarding.md
+++ b/meta/resources/offboarding.md
@@ -12,13 +12,18 @@ choose to do so.
 3. Remove any division roles that they may have.
 4. Update [CODEOWNERS](/.github/CODEOWNERS) in the [purduehackers/evergreen](https://github.com/purduehackers/evergreen)
    repository to avoid tagging them in future PRs.
-5. Replace `admin` access to any repositories that they may have with `write` access.
-6. Remove them from the Google Drive and any other shared resources.
-7. Ask [@infinidoge](https://github.com/purduehackers/dark-forest/blob/main/people/organizers/infinidoge.md) to remove them
-   from the access list for the [Lawson Office](/meta/locations/lawson-office.md).
-8. Update the [Roles](/meta/structure/roles.md) document to reflect the change.
-9. Give them a shoutout in the [#core](https://discord.com/channels/772576325897945119/890595036855685181) channel in
-   Discord :)
+5. Re-assign any issues, PRs, or tasks that they are assigned to another organizer.
+6. Update references in [purduehackers/evergreen](https://github.com/purduehackers/evergreen) to reflect
+   new owners of projects and tasks.
+7. Update [purduehackers/dark-forest](https://github.com/purduehackers/dark-forest), moving them to
+   the `people/past-organizers` directory.
+8. Move them from the Organizers team to the Alumni team in the Github organization.
+9. Remove them from the Google Drive and any other shared resources.
+10. Ask [@infinidoge](https://github.com/purduehackers/dark-forest/blob/main/people/organizers/infinidoge.md) to remove them
+    from the access list for the [Lawson Office](/meta/locations/lawson-office.md).
+11. Update the [Roles](/meta/structure/roles.md) document to reflect the change.
+12. Give them a shoutout in the [#core](https://discord.com/channels/772576325897945119/890595036855685181) channel in
+    Discord :)
 
 ## Special Cases
 


### PR DESCRIPTION
Update off-boarding procedures to have more information pertaining to Github ACLs and Evergreen references.

Closes #55 
Closes #36