### PR TITLE
Reprioritize Ray as a global code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,6 @@
+# Evergreen project owner
+*                                       @rayhanadev
+
 /meta/                                  @MatthewStanciu @rayhanadev
 
 # Comms Division

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,6 +51,3 @@
 /design/                                # No one owns this yet
 /events/                                @rayhanadev
 /finances/                              @joshamstutz
-
-# Documentation Lead
-*                                       @rayhanadev


### PR DESCRIPTION
As written Ray needs to approve every PR so codeowners are effectively useless