### PR TITLE
Improvements to making-badges.md and standards.md

### DIFF
--- a/design/badges/making-badges.md
+++ b/design/badges/making-badges.md
@@ -1,4 +1,4 @@
-This file serves as a guide on how to make badges / stamps for Hack Night.
+This file serves as a step-by-step guide on how to make badges / stamps for Hack Night.
 
 Outline:
 1. Brainstorm an idea
@@ -18,34 +18,20 @@ Also consider basing the badge off of an idea rather than a specific thing like 
 
 # 2. Buy acrylic
 We get a lot of our acrylic from [Canal Plastics Center](https://www.canalplastic.com/products/0b008-rt-radiant-iridescent-acrylic-sheet) but Amazon and others are fine too.
-One 12x18 sheet with 1/8" thickness have produced 35-50 badges. Consider the theme to find a fitting acrylic or find something cool and inspiring! <br> <br>
+One 12x18 sheet with 1/8" thickness has produced 35-50 badges. Consider the theme to find a fitting acrylic or find something cool and inspiring! <br> <br>
 More details at [ordering-material.md](ordering-material.md).
 
 # 3. Design the badge
 Starting with a drawing can help. Then import the drawing into a vector graphics software of your choice and trace around to make your design come alive digitally. Figma, Illustrator, or Vectr are probably your best bet. <br> <br>
 Black = engrave. Red = cut. <br> <br>
-The laser cutter can be picky about the cutting path. For details see [Cutting Path](#cutting-path) <br>
 
-Please follow the standards in [standards.md](/design/badges/standards.md) to ensure your badge design remains problem-free.
+Make sure to read [standards.md](/design/badges/standards.md) and follow the instructions within to ensure your badge design remains problem-free.
 
-Note on engraving: you can use shades to control the strength of the engraving. Some acrylic such as the "pearl" kinds don't engrave as dramatically as others so you can increase the cut strength on Ruby. Also, you can do intricate designs with the engravings as the laser cutter makes a standard pass through the whole acrylic sheet, but intricate cutting paths can increase laser cutting times. <br> <br>
+Read standards.md! Read it again! There are many problems people run into that have been documented. Hopefully this will cut down on the number of problems found when it comes time to laser cut.
 
-**When you're finished, export your design in .svg and put it on Figma.**
+**When you're finished, export your design as an SVG and put it on Figma.**
 
-## Common Pitfalls
-* If you use text effects like warp or use fonts that don't exist on Figma, you need to "Create Outline" of the text. This will make the text vector shapes. Note that this results in the text being non-editable so do this after you've finalized the design or after you make a backup.
-* Always make sure the cut line is `#FF0000`, not any other shade of red. Trotec Ruby only recognizes `#FF0000`. This can be fixed in Ruby itself, so it's not a big deal, but it's better to get it right in the design so that we don't risk missing it when we make the badge & not having the cut line work.
-### Cutting Path
-There are three main things that can happen: <br>
-* Correct: If you import a connected path of a red line from your graphics software of choice, Figma will see it as a single vector path, Ruby (software for laser cutting) sees it as a vector, the laser cutter does one smooth pass
-* Slightly Incorrect: If you use Joins on Figma to create your badge outline, Figma sees it as a single vector path, Ruby sees it as a complex object but still recognizes it as a cut line which causes the laser cutter to jump around and make redundant cuts
-* Incorrect: If you use a shape as a cut line, Figma sees it as a fill, ruby sees it as a complex object and does not recognize it as a cut line so make sure that the red path indicating where to cut is not an outline of an object but a standalone path with a red stroke.
-### Engraving
-* Make sure all engraving lines have a thickness of at least 3px — 1px and 2px lines don't show up well when laser cut.
-* You can actually use any grayscale color, from `#000000` to `#FFFFFF`, for the engraving. The lighter the engraving color, the less power the laser cutter will use for that segment of the engraving, with black being full power. But please use this wisely and sparingly:
-  * The grayscale is not simply a map between light engraving and dark engraving; lighter engravings also have an increased "dithering" effect. See the badges for 3.0 beta, 3.6, and 4.2 for some examples.
-  * You need *lots* of contrast between colors, otherwise it will appear muddy. See the Hack Night 2.3 ("scuba") badge for an example of how a seemingly good-looking design can actually look muddy and low-contrast on the actual badge.
-  * Avoid more than 2 or 3 grayscale colors in a badge design. Can't stress enough: **If you do a grayscale engraving, it will appear much lower-contrast on the badge itself vs. in the design.**
+
 
 # 4. Design the stamp
 Draw inspiration from an actual stamp shape, generate a blob, make a shape that inspires you, or take a shape from a previous stamp. <br>
@@ -53,23 +39,21 @@ Then alter your badge design so that it is only black and white. It can also som
 Fill your stamp shape with white and add an inner stroke of black and 5px. <br>
 Add the titles of the stamp (- Hack Night ## - MM DD YYYY -) and update it to current date and version number. <br>
 Align everything together to where you want everything to be. Select everything and invert the colors. <br>
-Now copy paste the outline shape, get rid of the fill, and make it red (#FF0000). <br><br>
+Now copy paste the outline shape, get rid of the fill, and make it red (`#FF0000`). <br><br>
 This process is very doable within Figma, but if it isn't on there already, put your stamp design on Figma as well.
-
-## Common pitfalls
 
 * Although grayscale is allowed in badge designs, never use grayscale in a stamp; **only use `#000000` and `#FFFFFF`.
   * If you think about the way the stamp works: the laser cutter will engrave (or, shave a layer off the top of) the rubber everywhere it's black, and leave everything that's white. So the white parts will be protruding out uniformly, and black parts inward uniformly, so the white parts will stamp nicely. If you add grayscale, it will just shave off less of the top of the rubber, so it'll be set inward from the white parts and won't appear when you actually stamp it.
 
 # 5. Laser cut badge
 Prerequisite: be certified and reserve a time slot.
-I imagine most of the information below will be learned when you get laser cutter certified <br> <br>
+I imagine most of the information below will be learned when you get laser cutter certified <br>
 
 Export the stamp and badge designs separately as SVG files and put them on a USB.
 Once you're in the lab, move the designs to Ruby Trotec on the design tab and set the size of the badge on the prepare tab.
 Set the material you are cutting on.
 Align the badges on the page to optimize space and make them fit on the size of the acrylic sheet. A lot of copy paste and resizing.
-Calculate job time and you can create a job. <br> <br>
+Calculate job time and you can create a job. <br>
 
 Place acrylic on the plate of the laser cutter and push it to the top left.
 Put the metal thing on the laser and push the plate up so that there is a precise distance between laser and acrylic. Move laser to zero position (top left).

--- a/design/badges/standards.md
+++ b/design/badges/standards.md
@@ -1,27 +1,61 @@
-# Badge standards for less problems
+# Badge standards
 
 ## Software
 Any vector design software that can export as SVG (Scalable Vector Graphics). Adobe Illustrator and Inkscape are the most commonly-used ones.
 
 Inkscape is free, so if you don't have a Creative Cloud subscription etc., it's a good place to start.
 
-## Building your badge
-Unless you are tracing over a design or have a complex design that requires a lot of nodes, refrain from using lines to build your badge, especially if this is your first one. The easiest way to begin building is by using primitives (circles, squares, polygons).
+## Where to start?
+If this is your first badge, the easiest way to begin building is by using primitives (circles, squares, polygons).
 
-### Why should I use primitives?  
-Because I said so. 
+It is very easy to shape primitives to your desire as they have a minimal amount of points and can be very easily adjusted. Unless your badge is some complex shape, then everything can be built out of rectangles, ellipses, or triangles. Most vector softwares should also have a shape builder tool that makes combining primitives easy. If your badge is a simple shape made up of primitives, you can simply duplicate the final shape and get rid of the fill in order to create the cut line around the outside of your badge.
 
-Joking aside, it's very easy to shape primitives to your desire as they have a minimal amount of points and can be very easily adjusted. Unless your badge is some complex shape, then everything can be built out of rectangles, ellipses, or triangles. Most vector softwares should also have a shape builder tool that makes combining primitives easy. Finally, you can simply duplicate the final shape and get rid of the fill in order to easily create the cut line around the outside of your badge.
-
-## Text
-Make sure you are certain that this is the font you want to use. Ensure the content inside your text is accurate (this means no typos, no wrong dates, and you are satisfied with the wording). Then flatten, convert object to path, whatever it is called on the software of your choice to convert the text to a vector. Make sure the ensuing vector does not have any outlines and is only fill. This means looking at the properties of the vector in your software and making sure there are no strokes or outlines or whatever they are called in your software, present. 
-
-### Why do we convert text to vectors?
-Fonts do not always translate accurately between softwares because some may not be available. Sometimes Figma, the place where we store all our badge designs, may not have the font you are using. This is particularly tricky if the font itself is a crucial part of your design (ex. Wingdings as a decorative border). If you like the look of a certain font then it is always better to flatten as an added security measure against Figma not having your font.
-
-### Why can't the text have strokes? I want to make my text bolder.
-Weird and dark magic will happen when exporting to Figma, where unneeded groups, masks and layers will be added. This will mess up the engraving when laser cutting. Even if it doesn't cause a problem, it is better to keep things simple to prevent last minute mishaps. If you want the text to be bolder, 90% of the time the font that you are using will probably have a bolder version. Again, make sure you are satsified with the look of the text before flattening.
+## Material choice
+See [ordering-material.md](ordering-material.md).
+Be aware that different materials will cause engravings to show more or less clearly. Generally, lighter colors are more difficult to see engravings on (because engravings are white). Pearl acrylics also make the engravings much fainter. For an example, see the 5.0 badge (fluorescent) vs the 5.7 badge (pearl).
 
 ## Colors
-If it is your first attempt at making a badge, do not attempt grayscale. If you must attempt greyscale, keep things high contrast in the design. Ruby does not do well with low contrast engravings. 
-Make sure everything is either FFFF00 or 000000, the colors needed to cut or engrave. This means everything. If another color is present then whatever has that color cannot be engraved or cut by Trotec Ruby.
+In this section, colors will be represented with hex codes. Hex codes can be 3 (`#xxx`) or 6 (`#xxxxxx`) digits. For the sake of simplicity, hex codes in this document will be represented by a 3-digit code. To get the corresponding 6-digit code, simply double each digit. For example, `#F00` -> `#FF0000`
+
+Trotec Ruby will recognize any grayscale color from `#000` to `#FFF`, and will recognize `#F00` as the cut path. Any other color cannot be engraved or cut by Trotec Ruby.
+
+If it is your first attempt at making a badge, do not attempt grayscale. Instead, make sure everything is either `#F00`, for the cut path, `#FFF`, for no engraving, or `#000`, for engraving.
+
+## Engraving
+* Make sure all engraving lines have a thickness of at least 3% the size of the badge. Engraving patterns that are too thin will not show up well.
+* You can actually use any grayscale color, from `#000` to `#FFF`, for the engraving. The lighter the engraving color, the less power the laser cutter will use for that segment of the engraving. (black being full power, and white being no power). But please use this wisely and sparingly:
+    * The grayscale is not simply a map between light engraving and dark engraving; lighter engravings also have an increased "dithering" effect. See the badges for 3.0 beta, 3.6, and 4.2 for some examples.
+    * You need *lots* of contrast between colors, otherwise it will appear muddy. Ruby does not do well with low-contrast engravings. See the Hack Night 2.3 ("scuba") badge for an example of how a seemingly good-looking design can actually look muddy and low-contrast on the actual badge.
+    * Avoid more than 2 or 3 grayscale colors in a badge design. Can't stress enough: **If you do a grayscale engraving, it will appear much lower-contrast on the badge itself vs. in the design.**
+
+## Cutting Path
+There are three main things that can happen:
+* Correct: If you import a connected path of a red line from your graphics software of choice, Figma will see it as a single vector path, Ruby (software for laser cutting) sees it as a vector, the laser cutter does one smooth pass
+* Slightly Incorrect: If you use Joins on Figma to create your badge outline, Figma sees it as a single vector path, Ruby sees it as a complex object but still recognizes it as a cut line which causes the laser cutter to jump around and make redundant cuts
+* Incorrect: If you use a shape as a cut line, Figma sees it as a fill, ruby sees it as a complex object and does not recognize it as a cut line so make sure that the red path indicating where to cut is not an outline of an object but a standalone path with a red stroke.
+**TODO: put information here about how thick the physical cut actually is.**
+
+## A brief warning on formatting
+You will be creating a design, exporting to a figma document, and then further exporting to Trotec Ruby for cutting. This makes for at least two, and most likely three, separate pieces of software the SVG has to go through. The following sections are dedicated to minimizing the issues that arise when moving between each program. 
+
+## Text
+By default, text you create is a text object that requires a font. The fonts you have on your computer are likely different from the fonts figma has, which means that text will not look right when you export it. To solve this, before exporting, make sure to convert your text to a series of vector paths. 
+
+Before you do so, make extra certain that your text is accurate and / or keep a backup of your text. Check for typos, incorrect dates, version numbers, and unsatisfactory wording. You will not be able to edit your text easily after converting it.
+
+The process for converting is different depending on the program you are running. 
+- In illustrator, do Type -> Create Outlines
+- In inkscape, do Path -> Stroke to Path
+- In adobe animate, select everything and then break apart twice
+
+## Outlines / Strokes
+When you are drafting your design, you may have strokes in your file. Strokes will not resize proportionally when resizing the design in figma, and thus should be converted to paths before exporting. To do this,
+- In illustrator, do Object -> Path -> Outline Stroke
+- In inkscape, do Path -> Stroke to Path
+- In adobe animate, do Modify -> Shape -> Convert lines to fills
+
+The one exception to this rule is the cut path, which should remain as a stroke. This is because the goal is to cut a path, not an area.
+
+## Other Various Pitfalls
+* Always make sure the cut line is `#F00`, not any other shade of red. Trotec Ruby only recognizes `#F00`. This can be fixed in Ruby itself, so it's not a big deal, but it's better to get it right in the design so that we don't risk missing it when we make the badge & not having the cut line work.
+* If you are using adobe illustrator, make sure your color mode is set to RGB. You can check this by going to File -> Document Color Mode and setting it to RGB Color. If it is not set to RGB Color, the colors will change on export without you noticing and bad things will happen.

--- a/design/badges/standards.md
+++ b/design/badges/standards.md
@@ -20,7 +20,7 @@ In this section, colors will be represented with hex codes. Hex codes can be 3 (
 
 Trotec Ruby will recognize any grayscale color from `#000` to `#FFF`, and will recognize `#F00` as the cut path. Any other color cannot be engraved or cut by Trotec Ruby.
 
-If it is your first attempt at making a badge, do not attempt grayscale. Instead, make sure everything is either `#F00`, for the cut path, `#FFF`, for no engraving, or `#000`, for engraving.
+If it is your first attempt at making a badge, do not attempt grayscale. Instead, make sure everything is either `#F00` (red), for the cut path, `#FFF` (white), for no engraving, or `#000` (black), for engraving.
 
 ## Engraving
 * Make sure all engraving lines have a thickness of at least 3% the size of the badge. Engraving patterns that are too thin will not show up well.

--- a/design/badges/standards.md
+++ b/design/badges/standards.md
@@ -12,6 +12,7 @@ It is very easy to shape primitives to your desire as they have a minimal amount
 
 ## Material choice
 See [ordering-material.md](ordering-material.md).
+
 Be aware that different materials will cause engravings to show more or less clearly. Generally, lighter colors are more difficult to see engravings on (because engravings are white). Pearl acrylics also make the engravings much fainter. For an example, see the 5.0 badge (fluorescent) vs the 5.7 badge (pearl).
 
 ## Colors

--- a/design/badges/standards.md
+++ b/design/badges/standards.md
@@ -37,7 +37,7 @@ There are three main things that can happen:
 **TODO: put information here about how thick the physical cut actually is.**
 
 ## A brief warning on formatting
-You will be creating a design, exporting to a figma document, and then further exporting to Trotec Ruby for cutting. This makes for at least two, and most likely three, separate pieces of software the SVG has to go through. The following sections are dedicated to minimizing the issues that arise when moving between each program. 
+You will be creating a design, exporting to a Figma document, and then further exporting to Trotec Ruby for cutting. This makes for at least two, and most likely three, separate pieces of software the SVG has to go through. The following sections are dedicated to minimizing the issues that arise when moving between each program. 
 
 ## Text
 By default, text you create is a text object that requires a font. The fonts you have on your computer are likely different from the fonts figma has, which means that text will not look right when you export it. To solve this, before exporting, make sure to convert your text to a series of vector paths. 


### PR DESCRIPTION
I have moved the common pitfalls and cut information to standards.md to clarify the purpose of each file. Making-badges serves as more of a step-by-step overview of the process, while standards serves as a more specific deep dive into the design process, and has the potential issues.

I give the advice to convert all strokes into filled outlines, for better standardization. I also tried to remove pixel measurements and replace them with percent or physical size measurements, as those are more consistent. I also gave specific instructions for each program.

I added a lot more color mentions, and so used 3-digit hex codes. I thought this would be more readable. If this is just more confusing, I can change them back to 6 digits.

I have removed the paragraph about not adding strokes to text. I believe this is fine, as the issue with stroked text in previous badges has been the same issue that should be fixed by turning all strokes into outlines.