### PR TITLE
Add Obsidian Gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.obsidian


### PR DESCRIPTION
Add the `.obsidian/` folder to .gitignore, allowing folks to setup individual evergreen vaults.